### PR TITLE
Add QR code generation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,6 +666,7 @@ You can customize the styles by modifying the CSS files or using a CSS-in-JS sol
 
 - The compressed URL is displayed below the form.
 - Click the **"Copy"** button to copy it to your clipboard.
+- A QR code for the short URL is also displayed for quick scanning.
 - Use the compressed URL in your browser or share it with others.
 
 ---

--- a/UrlCompressorApi/UrlCompressorApi.py
+++ b/UrlCompressorApi/UrlCompressorApi.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from datetime import datetime, timedelta
 from models import Base, URLMapping
 from database import engine, get_db
-from services import URLShortenerService
+from services import URLShortenerService, QRCodeService
 from schemas import URLCreateRequest, URLCreateResponse
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -18,6 +18,7 @@ app = FastAPI()
 # Service responsible for Base62 encoding/decoding of IDs
 url_service = URLShortenerService()
 
+qr_service = QRCodeService()
 # Configure CORS middleware to allow frontend requests
 app.add_middleware(
     CORSMiddleware,
@@ -74,8 +75,8 @@ def create_short_url(
 
     # Construct the full short URL to return using request_obj
     short_url = f"{request_obj.base_url}{short_code}"
-    return {"short_url": short_url}  # Return the short URL to the client
-
+    qr_code = qr_service.generate_qr_base64(short_url)
+    return {"short_url": short_url, "qr_code": qr_code}
 
 @app.get("/{short_code}")
 def redirect_to_original(short_code: str, db: Session = Depends(get_db)):

--- a/UrlCompressorApi/requirements.txt
+++ b/UrlCompressorApi/requirements.txt
@@ -5,3 +5,6 @@ pydantic
 aiofiles
 jinja2
 httpx
+
+qrcodegen
+pypng

--- a/UrlCompressorApi/schemas.py
+++ b/UrlCompressorApi/schemas.py
@@ -7,3 +7,4 @@ class URLCreateRequest(BaseModel):
 
 class URLCreateResponse(BaseModel):
     short_url: str  # The generated short URL to return to the client
+    qr_code: str  # Base64-encoded PNG QR code

--- a/UrlCompressorApi/services.py
+++ b/UrlCompressorApi/services.py
@@ -2,6 +2,10 @@
 
 import string
 
+import base64
+from io import BytesIO
+import png
+import qrcodegen
 
 class URLShortenerService:
     """
@@ -38,3 +42,22 @@ class URLShortenerService:
             # ValueError will be raised if an invalid character is supplied
             num = num * self.base + self.alphabet.index(char)
         return num
+
+class QRCodeService:
+    """Generate base64-encoded QR codes using only MIT-licensed libraries."""
+
+    def __init__(self, border: int = 4):
+        self.border = border
+
+    def generate_qr_base64(self, data: str) -> str:
+        qr = qrcodegen.QrCode.encode_text(data, qrcodegen.QrCode.Ecc.MEDIUM)
+        size = qr.get_size()
+        size_with_border = size + 2 * self.border
+        matrix = [[0] * size_with_border for _ in range(size_with_border)]
+        for y in range(size):
+            for x in range(size):
+                if qr.get_module(x, y):
+                    matrix[y + self.border][x + self.border] = 1
+        with BytesIO() as output:
+            png.Writer(size_with_border, size_with_border, bitdepth=1).write(output, matrix)
+            return base64.b64encode(output.getvalue()).decode("ascii")

--- a/UrlCompressorApp/src/App.js
+++ b/UrlCompressorApp/src/App.js
@@ -11,18 +11,19 @@ class App extends Component {
         super(props);
         this.state = {
             shortURL: '',
+            qrCode: ''
         };
 
         // Bind the method to access 'this'
         this.setShortURL = this.setShortURL.bind(this);
     }
 
-    setShortURL(newURL) {
-        this.setState({ shortURL: newURL });
+    setShortURL(newURL, qrCode) {
+        this.setState({ shortURL: newURL, qrCode });
     }
 
     render() {
-        const { shortURL } = this.state;
+        const { shortURL, qrCode } = this.state;
         console.log("Host URL: " + process.env.PUBLIC_URL);
 
         return (
@@ -30,7 +31,7 @@ class App extends Component {
                 <div className="app-container">
                     <h1>URL Compressor</h1>
                     <ShortenURLForm setShortURL={this.setShortURL} />
-                    {shortURL && <URLResult shortURL={shortURL} />}
+                    {shortURL && <URLResult shortURL={shortURL} qrCode={qrCode} />}
                 </div>
             </Router>
         );

--- a/UrlCompressorApp/src/components/ShortenUrlForm.jsx
+++ b/UrlCompressorApp/src/components/ShortenUrlForm.jsx
@@ -16,7 +16,7 @@ function ShortenURLForm({ setShortURL }) {
                 original_url: originalURL,
                 expiration_time: expirationTime ? parseInt(expirationTime, 10) : null,
             });
-            setShortURL(response.data.short_url);
+            setShortURL(response.data.short_url, response.data.qr_code);
             setOriginalURL('');
             setExpirationTime('');
         } catch (error) {

--- a/UrlCompressorApp/src/components/UrlResult.css
+++ b/UrlCompressorApp/src/components/UrlResult.css
@@ -48,3 +48,4 @@
         width: 90%;
     }
 }
+.qr-code-image {\n    margin-top: 20px;\n    width: 150px;\n    height: 150px;\n}

--- a/UrlCompressorApp/src/components/UrlResult.jsx
+++ b/UrlCompressorApp/src/components/UrlResult.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import './UrlResult.css';
 
-function URLResult({ shortURL }) {
+function URLResult({ shortURL, qrCode }) {
     const copyToClipboard = () => {
         navigator.clipboard.writeText(shortURL);
         alert('Short URL copied to clipboard!');
@@ -18,6 +18,7 @@ function URLResult({ shortURL }) {
                     Copy
                 </button>
             </div>
+            <img src={`data:image/png;base64,${qrCode}`} alt="QR Code" className="qr-code-image" />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- generate QR codes with MIT-licensed qrcodegen/pypng
- expose QR codes via API
- show QR code in React app with new styling
- document the new functionality

## Testing
- `python -m py_compile UrlCompressorApi.py models.py schemas.py services.py database.py`
- `pytest -q`
- `npm test --silent --unsafe-perm --prefix .` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ba14018f4832c93b1f3c810c22567