### PR TITLE
Fix Base62 encoding of zero and add regression test

### DIFF
--- a/UrlCompressorApi/services.py
+++ b/UrlCompressorApi/services.py
@@ -21,6 +21,8 @@ class URLShortenerService:
 
     def __init__(self):
         # Characters used for encoding (Base62)
+        # Default alphabet for Base62: letters followed by digits.
+        # The first character represents zero to ensure proper round trips.
         self.alphabet = string.ascii_letters + string.digits
         self.base = len(self.alphabet)  # Base62
 
@@ -29,6 +31,8 @@ class URLShortenerService:
         Encodes an integer ID to a Base62 string.
         Implements number-to-string conversion by repeatedly dividing the number by 62 and mapping remainders to characters.
         """
+        if num == 0:
+            return self.alphabet[0]
         s = []
         while num > 0:
             s.append(
@@ -36,7 +40,7 @@ class URLShortenerService:
             )  # Get the character for the remainder
             num //= self.base  # Reduce the number for next iteration
         # Reverse the list to get the correct order
-        return "".join(reversed(s)) or "0"  # Return '0' if num is 0
+        return "".join(reversed(s))
 
     def decode(self, short_code: str) -> int:
         """

--- a/UrlCompressorApi/tests/test_services.py
+++ b/UrlCompressorApi/tests/test_services.py
@@ -25,6 +25,13 @@ def test_encode_decode_roundtrip():
         code = service.encode(n)
         assert service.decode(code) == n
 
+
+def test_encode_decode_zero():
+    service = URLShortenerService()
+    code = service.encode(0)
+    assert code == service.alphabet[0]
+    assert service.decode(code) == 0
+
 def test_generate_qr_base64():
     qr_service = QRCodeService()
     data = 'https://example.com'


### PR DESCRIPTION
## Summary
- ensure Base62 encoder handles zero by returning the first alphabet character
- add test covering zero encode/decode behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbaf02ee2c832c88d2ca3751157008